### PR TITLE
wrap calls to destroy elements to shade console errors

### DIFF
--- a/src/data-table/custom-element.js
+++ b/src/data-table/custom-element.js
@@ -8,7 +8,7 @@ class MdcDataTable extends HTMLElement {
   }
 
   connectedCallback() {
-    this.datatable_ = new MDCDataTable(this);
+    this.dataTable_ = new MDCDataTable(this);
   }
 
   disconnectedCallback() {


### PR DESCRIPTION
Fixes errors caused by a little typo. I attached a screenshot to show these errors were also happening on the demo application.
![Screen Shot 2020-02-10 at 7 01 06 PM](https://user-images.githubusercontent.com/20078622/74208366-173d6300-4c38-11ea-807d-d127b78eb617.png)

They were of course triggered whenever a Datatable element was about to be destroyed.