### PR TITLE
Fix: Unhook body click handler when menu surface is destroyed

### DIFF
--- a/src/menu-surface/component.ts
+++ b/src/menu-surface/component.ts
@@ -95,6 +95,7 @@ export class MDCMenuSurface extends MDCComponent<MDCMenuSurfaceFoundation> {
   destroy() {
     this.unlisten('keydown', this.handleKeydown_);
     this.unlisten(strings.OPENED_EVENT, this.registerBodyClickListener_);
+    this.deregisterBodyClickListener_();
     this.unlisten(strings.CLOSED_EVENT, this.deregisterBodyClickListener_);
     super.destroy();
   }


### PR DESCRIPTION
I have an app which switches page when a menu entry is clicked, and so the menu is destroyed while open. This leaves the body click handler active, which then sends messages on every subsequent click, preventing the menu reopening when it is recreated.

This patch just tries to remove the handler when the menu surface is destroyed. I'm not sure why this isn't a problem for upstream, as it looks like they should also have this bug.