### PR TITLE
fix: SvgIcon was not handled by Snackbar

### DIFF
--- a/src/Material/Snackbar.elm
+++ b/src/Material/Snackbar.elm
@@ -591,7 +591,20 @@ actionIconElt messageId ((Message { actionIcon }) as message_) =
                     nodes
                 )
 
-        _ ->
+        Just (SvgIcon { node, attributes, nodes }) ->
+            Just
+                (node
+                    (List.filterMap identity
+                        [ Just (class "mdc-icon-button")
+                        , Just (class "mdc-snackbar__dismiss")
+                        , actionIconClickHandler messageId message_
+                        ]
+                        ++ attributes
+                    )
+                    nodes
+                )
+
+        Nothing ->
             Nothing
 
 


### PR DESCRIPTION
MCVE of the problem: https://ellie-app.com/b2qFBHz4PHYa1 The first popup has an icon, while the second doesn't. This PR just duplicates the normal Icon code, as other components seem to do.