### PR TITLE
Fix the disable option for icon buttons

### DIFF
--- a/src/Material/IconButton.elm
+++ b/src/Material/IconButton.elm
@@ -175,22 +175,25 @@ setOnClick onClick (Config config_) =
 -}
 iconButton : Config msg -> Icon -> Html msg
 iconButton ((Config { additionalAttributes }) as config_) icon_ =
-    Html.node "mdc-icon-button"
-        (List.filterMap identity
-            [ rootCs
-            , tabIndexProp
-            , clickHandler config_
-            ]
-            ++ additionalAttributes
-        )
-        [ Html.map never <|
-            case icon_ of
-                Icon { node, attributes, nodes } ->
-                    node (class "mdc-icon-button__icon" :: attributes) nodes
+    Html.node "mdc-icon-button" []
+        [ Html.button
+            (List.filterMap identity
+                [ rootCs
+                , tabIndexProp
+                , clickHandler config_
+                , disabledAttr config_
+                ]
+                ++ additionalAttributes
+            )
+            [ Html.map never <|
+                case icon_ of
+                    Icon { node, attributes, nodes } ->
+                        node (class "mdc-icon-button__icon" :: attributes) nodes
 
-                SvgIcon { node, attributes, nodes } ->
-                    node (Svg.Attributes.class "mdc-icon-button__icon" :: attributes)
-                        nodes
+                    SvgIcon { node, attributes, nodes } ->
+                        node (Svg.Attributes.class "mdc-icon-button__icon" :: attributes)
+                            nodes
+            ]
         ]
 
 
@@ -207,6 +210,11 @@ tabIndexProp =
 clickHandler : Config msg -> Maybe (Html.Attribute msg)
 clickHandler (Config { onClick }) =
     Maybe.map Html.Events.onClick onClick
+
+
+disabledAttr : Config msg -> Maybe (Html.Attribute msg)
+disabledAttr (Config { disabled }) =
+    Just (Html.Attributes.disabled disabled)
 
 
 {-| Icon type


### PR DESCRIPTION
Currently the disabled option for icon buttons does not work (https://ellie-app.com/bf6DZLKvVN6a1). This PR fixes that by placing a HTML `button` element inside the `mdc-icon-button`, similar to what is done for text buttons. The difference is that normal buttons can use either a `button` or an `a`, depending on the presence of a `href`. This PR does not extend icon buttons to support `href`s, but that could be done in the future.

For diff without whitespace changes, see https://github.com/aforemny/material-components-web-elm/commit/ab5ed805d456049f6968dafe409e04ee4ffe640d?w=1