### PR TITLE
Add setHref and setTarget to IconButtons

### DIFF
--- a/src/Material/IconButton.elm
+++ b/src/Material/IconButton.elm
@@ -2,6 +2,7 @@ module Material.IconButton exposing
     ( Config, config
     , setOnClick
     , setDisabled
+    , setHref, setTarget
     , setLabel
     , setAttributes
     , iconButton
@@ -57,6 +58,7 @@ tap.
 
 @docs setOnClick
 @docs setDisabled
+@docs setHref, setTarget
 @docs setLabel
 @docs setAttributes
 
@@ -133,6 +135,8 @@ config : Config msg
 config =
     Config
         { disabled = False
+        , href = Nothing
+        , target = Nothing
         , label = Nothing
         , additionalAttributes = []
         , onClick = Nothing
@@ -148,6 +152,28 @@ effect.
 setDisabled : Bool -> Config msg -> Config msg
 setDisabled disabled (Config config_) =
     Config { config_ | disabled = disabled }
+
+
+{-| Specify whether a button is a _link button_.
+
+Link buttons behave like normal HTML5 anchor tags. Note that link buttons
+cannot be disabled and ignore that configuration option.
+
+-}
+setHref : Maybe String -> Config msg -> Config msg
+setHref href (Config config_) =
+    Config { config_ | href = href }
+
+
+{-| Specify the target for a link button.
+
+Note that this configuration option will be ignored by buttons that do not also
+set `setHref`.
+
+-}
+setTarget : Maybe String -> Config msg -> Config msg
+setTarget target (Config config_) =
+    Config { config_ | target = target }
 
 
 {-| Specify an icon button's HTML5 arial-label attribute
@@ -174,12 +200,19 @@ setOnClick onClick (Config config_) =
 {-| Icon button view function
 -}
 iconButton : Config msg -> Icon -> Html msg
-iconButton ((Config { additionalAttributes }) as config_) icon_ =
+iconButton ((Config { additionalAttributes, href }) as config_) icon_ =
     Html.node "mdc-icon-button" []
-        [ Html.button
+        [ (if href /= Nothing then
+            Html.a
+
+            else
+            Html.button
+            )
             (List.filterMap identity
                 [ rootCs
                 , tabIndexProp
+                , hrefAttr config_
+                , targetAttr config_
                 , clickHandler config_
                 , disabledAttr config_
                 ]
@@ -205,6 +238,20 @@ rootCs =
 tabIndexProp : Maybe (Html.Attribute msg)
 tabIndexProp =
     Just (Html.Attributes.tabindex 0)
+
+
+hrefAttr : Config msg -> Maybe (Html.Attribute msg)
+hrefAttr (Config { href }) =
+    Maybe.map Html.Attributes.href href
+
+
+targetAttr : Config msg -> Maybe (Html.Attribute msg)
+targetAttr (Config { href, target }) =
+    if href /= Nothing then
+        Maybe.map Html.Attributes.target target
+
+    else
+        Nothing
 
 
 clickHandler : Config msg -> Maybe (Html.Attribute msg)

--- a/src/Material/IconButton.elm
+++ b/src/Material/IconButton.elm
@@ -175,22 +175,25 @@ setOnClick onClick (Config config_) =
 -}
 iconButton : Config msg -> Icon -> Html msg
 iconButton ((Config { additionalAttributes }) as config_) icon_ =
-    Html.node "mdc-icon-button"
-        (List.filterMap identity
-            [ rootCs
-            , tabIndexProp
-            , clickHandler config_
-            ]
-            ++ additionalAttributes
-        )
-        [ Html.map never <|
-            case icon_ of
-                Icon { node, attributes, nodes } ->
-                    node (class "mdc-icon-button__icon" :: attributes) nodes
+    Html.node "mdc-icon-button" []
+        [ Html.button
+            (List.filterMap identity
+                [ rootCs
+                , tabIndexProp
+                , clickHandler config_
+                , disabledAttr config_
+                ]
+                ++ additionalAttributes
+            )
+            [ Html.map never <|
+                case icon_ of
+                    Icon { node, attributes, nodes } ->
+                        node (class "mdc-icon-button__icon" :: attributes) nodes
 
-                SvgIcon { node, attributes, nodes } ->
-                    node (Svg.Attributes.class "mdc-icon-button__icon" :: attributes)
-                        nodes
+                    SvgIcon { node, attributes, nodes } ->
+                        node (Svg.Attributes.class "mdc-icon-button__icon" :: attributes)
+                            nodes
+            ]
         ]
 
 
@@ -207,6 +210,11 @@ tabIndexProp =
 clickHandler : Config msg -> Maybe (Html.Attribute msg)
 clickHandler (Config { onClick }) =
     Maybe.map Html.Events.onClick onClick
+
+
+disabledAttr : Config msg -> Maybe (Html.Attribute msg)
+disabledAttr (Config { disabled }) =
+    Just (Html.Attributes.disabled disabled)
 
 
 {-| Icon type

--- a/src/Material/IconButton/Internal.elm
+++ b/src/Material/IconButton/Internal.elm
@@ -7,6 +7,8 @@ import Svg exposing (Svg)
 type Config msg
     = Config
         { disabled : Bool
+        , href : Maybe String
+        , target : Maybe String
         , label : Maybe String
         , additionalAttributes : List (Html.Attribute msg)
         , onClick : Maybe msg


### PR DESCRIPTION
This PR essentially copies the code from Button, and is useful for `open_in_new` icon buttons, since Elm doesn't have a built in function for opening a new tab yet. This PR should probably be merged after #130 (and after a quick rebase).