### PR TITLE
upgrade virtual-dom to 1.0.3

### DIFF
--- a/demo/elm.json
+++ b/demo/elm.json
@@ -13,7 +13,7 @@
             "elm/json": "1.1.3",
             "elm/svg": "1.0.1",
             "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         },
         "indirect": {
             "elm/regex": "1.0.0",

--- a/demo/review/elm.json
+++ b/demo/review/elm.json
@@ -18,7 +18,7 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/time": "1.0.0",
-            "elm/virtual-dom": "1.0.2",
+            "elm/virtual-dom": "1.0.3",
             "elm-community/list-extra": "8.5.1",
             "elm-explorations/test": "1.2.2",
             "miniBill/elm-unicode": "1.0.2",

--- a/elm.json
+++ b/elm.json
@@ -63,7 +63,7 @@
         "elm/html": "1.0.0 <= v < 2.0.0",
         "elm/json": "1.1.3 <= v < 2.0.0",
         "elm/svg": "1.0.1 <= v < 2.0.0",
-        "elm/virtual-dom": "1.0.2 <= v < 2.0.0"
+        "elm/virtual-dom": "1.0.3 <= v < 2.0.0"
     },
     "test-dependencies": {}
 }

--- a/examples/simple-counter/elm.json
+++ b/examples/simple-counter/elm.json
@@ -12,7 +12,7 @@
             "elm/html": "1.0.0",
             "elm/json": "1.1.3",
             "elm/svg": "1.0.1",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         },
         "indirect": {
             "elm/regex": "1.0.0",

--- a/examples/theming/elm.json
+++ b/examples/theming/elm.json
@@ -17,7 +17,7 @@
             "elm/svg": "1.0.1",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     },
     "test-dependencies": {

--- a/review/elm.json
+++ b/review/elm.json
@@ -18,7 +18,7 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/time": "1.0.0",
-            "elm/virtual-dom": "1.0.2",
+            "elm/virtual-dom": "1.0.3",
             "elm-community/list-extra": "8.5.1",
             "elm-explorations/test": "1.2.2",
             "miniBill/elm-unicode": "1.0.2",


### PR DESCRIPTION
**Why:**
Fix security issue https://jfmengels.net/virtual-dom-security-patch/

https://github.com/aforemny/material-components-web-elm/issues/169