### PR TITLE
feat!: Remove Card.primaryAction

### DIFF
--- a/demo/src/Demo/Cards.elm
+++ b/demo/src/Demo/Cards.elm
@@ -60,13 +60,13 @@ heroCard =
     [ Card.card
         (Card.config
             |> Card.setAttributes [ style "width" "350px" ]
+            |> Card.setHref (Just "#cards")
         )
         { blocks =
-            Card.primaryAction []
-                [ demoMedia
-                , demoTitle
-                , demoBody
-                ]
+            [ demoMedia
+            , demoTitle
+            , demoBody
+            ]
         , actions = Just demoActions
         }
     ]
@@ -82,11 +82,10 @@ exampleCard1 =
                 ]
         )
         { blocks =
-            Card.primaryAction []
-                [ demoMedia
-                , demoTitle
-                , demoBody
-                ]
+            [ demoMedia
+            , demoTitle
+            , demoBody
+            ]
         , actions = Nothing
         }
 
@@ -101,10 +100,9 @@ exampleCard2 =
                 ]
         )
         { blocks =
-            Card.primaryAction []
-                [ demoTitle
-                , demoBody
-                ]
+            [ demoTitle
+            , demoBody
+            ]
         , actions = Just demoActions
         }
 
@@ -120,10 +118,9 @@ exampleCard3 =
                 ]
         )
         { blocks =
-            Card.primaryAction []
-                [ demoTitle
-                , demoBody
-                ]
+            [ demoTitle
+            , demoBody
+            ]
         , actions = Just demoActions
         }
 
@@ -140,10 +137,9 @@ focusCard =
                     ]
             )
             { blocks =
-                Card.primaryAction []
-                    [ demoTitle
-                    , demoBody
-                    ]
+                [ demoTitle
+                , demoBody
+                ]
             , actions = Just demoActions
             }
         , text "\u{00A0}"

--- a/demo/src/Demo/Menus.elm
+++ b/demo/src/Demo/Menus.elm
@@ -120,32 +120,31 @@ iconButtonWithinCardExample model =
     in
     Card.card (Card.config |> Card.setAttributes [ style "width" "350px" ])
         { blocks =
-            Card.primaryAction []
-                [ Card.block <|
-                    Html.div
-                        [ style "padding" "1rem" ]
-                        [ Html.h2
-                            [ Typography.headline6
-                            , style "margin" "0"
-                            ]
-                            [ text "Our Changing Planet" ]
-                        , Html.h3
-                            [ Typography.subtitle2
-                            , Theme.textSecondaryOnBackground
-                            , style "margin" "0"
-                            ]
-                            [ text "by Kurt Wagner" ]
+            [ Card.block <|
+                Html.div
+                    [ style "padding" "1rem" ]
+                    [ Html.h2
+                        [ Typography.headline6
+                        , style "margin" "0"
                         ]
-                , Card.block <|
-                    Html.div
-                        [ Typography.body2
+                        [ text "Our Changing Planet" ]
+                    , Html.h3
+                        [ Typography.subtitle2
                         , Theme.textSecondaryOnBackground
-                        , style "padding" "0 1rem 0.5rem 1rem"
+                        , style "margin" "0"
                         ]
-                        [ text
-                            "Visit ten places on our planet that are undergoing the biggest changes today."
-                        ]
-                ]
+                        [ text "by Kurt Wagner" ]
+                    ]
+            , Card.block <|
+                Html.div
+                    [ Typography.body2
+                    , Theme.textSecondaryOnBackground
+                    , style "padding" "0 1rem 0.5rem 1rem"
+                    ]
+                    [ text
+                        "Visit ten places on our planet that are undergoing the biggest changes today."
+                    ]
+            ]
         , actions =
             Just <|
                 Card.actions


### PR DESCRIPTION
BREAKING CHANGE: The block `Card.primaryAction` has been removed. Instead, a configuration option `Card.setOnClick` has been added.

Before:
```
Card.card Card.config
    { blocks =
        Card.primaryAction [ Html.Events.onClick Clicked ]
            [ block1
            , block2
            ]
    , actions = Nothing
    }
```

After:
```
Card.card
    (Card.config
        |> Card.setOnClick Clicked
    )
    { blocks =
        [ block1
        , block2
        ]
    , actions = Nothing
    }
```

Additionally, configuration options `Card.setHref`, `Card.setTarget` have been added to facilitate link actions.