### PR TITLE
feat!: Disallow cards without blocks

### DIFF
--- a/demo/src/Demo/Cards.elm
+++ b/demo/src/Demo/Cards.elm
@@ -63,10 +63,11 @@ heroCard =
             |> Card.setHref (Just "#cards")
         )
         { blocks =
-            [ demoMedia
-            , demoTitle
-            , demoBody
-            ]
+            ( demoMedia
+            , [ demoTitle
+              , demoBody
+              ]
+            )
         , actions = Just demoActions
         }
     ]
@@ -82,10 +83,11 @@ exampleCard1 =
                 ]
         )
         { blocks =
-            [ demoMedia
-            , demoTitle
-            , demoBody
-            ]
+            ( demoMedia
+            , [ demoTitle
+              , demoBody
+              ]
+            )
         , actions = Nothing
         }
 
@@ -100,9 +102,10 @@ exampleCard2 =
                 ]
         )
         { blocks =
-            [ demoTitle
-            , demoBody
-            ]
+            ( demoTitle
+            , [ demoBody
+              ]
+            )
         , actions = Just demoActions
         }
 
@@ -118,9 +121,10 @@ exampleCard3 =
                 ]
         )
         { blocks =
-            [ demoTitle
-            , demoBody
-            ]
+            ( demoTitle
+            , [ demoBody
+              ]
+            )
         , actions = Just demoActions
         }
 
@@ -137,9 +141,10 @@ focusCard =
                     ]
             )
             { blocks =
-                [ demoTitle
-                , demoBody
-                ]
+                ( demoTitle
+                , [ demoBody
+                  ]
+                )
             , actions = Just demoActions
             }
         , text "\u{00A0}"

--- a/demo/src/Demo/Menus.elm
+++ b/demo/src/Demo/Menus.elm
@@ -120,7 +120,7 @@ iconButtonWithinCardExample model =
     in
     Card.card (Card.config |> Card.setAttributes [ style "width" "350px" ])
         { blocks =
-            [ Card.block <|
+            ( Card.block <|
                 Html.div
                     [ style "padding" "1rem" ]
                     [ Html.h2
@@ -135,16 +135,17 @@ iconButtonWithinCardExample model =
                         ]
                         [ text "by Kurt Wagner" ]
                     ]
-            , Card.block <|
-                Html.div
-                    [ Typography.body2
-                    , Theme.textSecondaryOnBackground
-                    , style "padding" "0 1rem 0.5rem 1rem"
-                    ]
-                    [ text
-                        "Visit ten places on our planet that are undergoing the biggest changes today."
-                    ]
-            ]
+            , [ Card.block <|
+                    Html.div
+                        [ Typography.body2
+                        , Theme.textSecondaryOnBackground
+                        , style "padding" "0 1rem 0.5rem 1rem"
+                        ]
+                        [ text
+                            "Visit ten places on our planet that are undergoing the biggest changes today."
+                        ]
+              ]
+            )
         , actions =
             Just <|
                 Card.actions

--- a/src/Material/Card.elm
+++ b/src/Material/Card.elm
@@ -53,15 +53,16 @@ module Material.Card exposing
     main =
         Card.card Card.config
             { blocks =
-                [ Card.block <|
+                ( Card.block <|
                     Html.div []
                         [ Html.h2 [] [ text "Title" ]
                         , Html.h3 [] [ text "Subtitle" ]
                         ]
-                , Card.block <|
-                    Html.div []
-                        [ Html.p [] [ text "Lorem ipsum…" ] ]
-                ]
+                , [ Card.block <|
+                        Html.div []
+                            [ Html.p [] [ text "Lorem ipsum…" ] ]
+                  ]
+                )
             , actions =
                 Just <|
                     Card.actions
@@ -101,9 +102,10 @@ to `True`.
     Card.card
         (Card.config |> Card.setOutlined True)
         { blocks =
-            [ Card.block <|
+            ( Card.block <|
                 Html.div [] [ Html.h1 [] [ text "Card" ] ]
-            ]
+            , []
+            )
         , actions = Nothing
         }
 
@@ -178,7 +180,11 @@ option to specify a target.
             |> Card.setHref (Just "#")
             |> Card.setTarget (Just "_blank")
         )
-        { blocks = []
+        { blocks =
+            ( Card.block <|
+                Html.div [] [ Html.h1 [] [ text "Card" ] ]
+            , []
+            )
         , actions = Nothing
         }
 
@@ -195,7 +201,11 @@ Note that cards must have a primary action element to be focusable.
             |> Card.setAttributes
                 [ Html.Attributes.id "my-card" ]
         )
-        { blocks = []
+        { blocks =
+            ( Card.block <|
+                Html.div [] [ Html.h1 [] [ text "Card" ] ]
+            , []
+            )
         , actions = Nothing
         }
 
@@ -305,7 +315,7 @@ blocksElt ((Config { onClick, href }) as config_) { blocks } =
           else
             identity
          )
-            blocks
+            (Tuple.first blocks :: Tuple.second blocks)
         )
 
 
@@ -378,7 +388,7 @@ outlinedCs (Config { outlined }) =
 {-| The content of a card is comprised of _blocks_ and _actions_.
 -}
 type alias Content msg =
-    { blocks : List (Block msg)
+    { blocks : ( Block msg, List (Block msg) )
     , actions : Maybe (Actions msg)
     }
 


### PR DESCRIPTION
BREAKING CHANGE: Card's content blocks have been changed from a list of blocks to a non-empty list of blocks. This guarantees that a card has at least one block.

Before:
```
Card.card
    Card.config
    { blocks = [ block1 ]
    , actions = Nothing
    }
```

After:
```
Card.card
    Card.config
    { blocks = ( block1, [] )
    , actions = Nothing
    }
```